### PR TITLE
thread: avoid logging error for nil actionQueue requests after channel close

### DIFF
--- a/thread.go
+++ b/thread.go
@@ -163,7 +163,9 @@ func (t *thread) run() {
 			}
 		case actionReq := <-t.actionQueue:
 			// Queue all control actions, execute in order after tasks are done
-			pendingActions = append(pendingActions, actionReq)
+			if actionReq != nil {
+				pendingActions = append(pendingActions, actionReq)
+			}
 			continue
 		}
 	}


### PR DESCRIPTION
thread: avoid logging error for nil actionQueue requests after channel close

- Prevent nil values from being added to pendingActions when reading from actionQueue in thread.run.
- This avoids unnecessary "executeAction called with nil request" error logs during thread shutdown.
- Improves shutdown clarity and prevents misleading error messages.